### PR TITLE
Particle injection bug from restart corrected

### DIFF
--- a/fields/EMfields3D.cpp
+++ b/fields/EMfields3D.cpp
@@ -730,16 +730,11 @@ void EMfields3D::adjustNonPeriodicDensities(int is, VirtualTopology3D * vct) {
 
 void EMfields3D::ConstantChargeOpenBCv2(Grid * grid, VirtualTopology3D * vct) {
 
-  double ff;
-
   int nx = grid->getNXN();
   int ny = grid->getNYN();
   int nz = grid->getNZN();
 
   for (int is = 0; is < ns; is++) {
-
-    ff = 1.0;
-    if (is == 0) ff = -1.0;
 
     if(vct->getXleft_neighbor()==MPI_PROC_NULL && bcEMfaceXleft ==2) {
       for (int j=0; j < ny;j++)
@@ -807,16 +802,13 @@ void EMfields3D::ConstantChargeOpenBCv2(Grid * grid, VirtualTopology3D * vct) {
 
 void EMfields3D::ConstantChargeOpenBC(Grid * grid, VirtualTopology3D * vct) {
 
-  double ff;
-
   int nx = grid->getNXN();
   int ny = grid->getNYN();
   int nz = grid->getNZN();
 
   for (int is = 0; is < ns; is++) {
 
-    ff = 1.0;
-    if (is == 0) ff = -1.0;
+    double ff = (qom[is] / fabs(qom[is]));
 
     if(vct->getXleft_neighbor()==MPI_PROC_NULL && (bcEMfaceXleft ==2)) {
       for (int j=0; j < ny;j++)
@@ -887,10 +879,8 @@ void EMfields3D::ConstantChargePlanet(Grid * grid, VirtualTopology3D * vct, doub
   double xd;
   double yd;
   double zd;
-  double ff;
 
   for (int is = 0; is < ns; is++) {
-    ff = (qom[is] / fabs(qom[is]));
     for (int i = 1; i < nxn; i++) {
       for (int j = 1; j < nyn; j++) {
         for (int k = 1; k < nzn; k++) {
@@ -900,7 +890,7 @@ void EMfields3D::ConstantChargePlanet(Grid * grid, VirtualTopology3D * vct, doub
           zd = fabs(grid->getZN(i,j,k) - z_center) - dz;
 
           if ((xd*xd+yd*yd+zd*zd) < R*R) {
-            rhons[is][i][j][k] = ff * rhoINJECT[is] / FourPI;
+            rhons[is][i][j][k] = (qom[is] / fabs(qom[is])) * rhoINJECT[is] / FourPI;
           }
 
         }
@@ -2168,16 +2158,17 @@ void EMfields3D::initBEAM(VirtualTopology3D * vct, Grid * grid, Collective *col,
 
 void EMfields3D::UpdateFext(int cycle){
 
-  double t_beg = 1.0;
-  double t_end = 1000.0;
-  double Fmin  = 0.75;
+  double t_beg = 500.0;
+  double t_end = 3000.0;
+  double Fmin  = 0.02;
   double Fmax  = 1.0;
 
   double m     = (Fmax - Fmin) / (t_end - t_beg);
   double b     = Fmax - m*t_end;
 
-  Fext = m * cycle + b;
+  //Fext = m * cycle + b;
 
+  if (cycle%int((t_end-t_beg)/9) == 0) Fext += (Fmax-Fmin)/10.0;
   if (cycle < t_beg) Fext = Fmin;
   if (cycle > t_end) Fext = Fmax;
 
@@ -2404,14 +2395,14 @@ void EMfields3D::SetLambda(Grid *grid){
         double y = grid->getYN(i,j,k);
         double z = grid->getZN(i,j,k);
 
-        double xmin_r = Lx - 50.0 * dx;
-        double xmax_r = Lx - 5.0  * dx;
+        double xmin_r = Lx - 75.0 * dx;
+        double xmax_r = Lx - 25.0  * dx;
 
         Lambda[i][j][k] = 0.0;
 
         if (x > xmin_r) {
-          if (x < xmax_r) Lambda[i][j][k] = ((x - xmin_r) /  (xmax_r - xmin_r)) * 2.0 * M_PI / dx;
-          else            Lambda[i][j][k] = 2.0 * M_PI / dx;
+          if (x < xmax_r) Lambda[i][j][k] = ((x - xmin_r) /  (xmax_r - xmin_r)) * 4.0 * M_PI / dx;
+          else            Lambda[i][j][k] = 4.0 * M_PI / dx;
         }
 
       }

--- a/iPic3D.cpp
+++ b/iPic3D.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
   /* 1- Main loop */
   /* ------------ */
 
-  for (int i = KCode.FirstCycle(); i <= KCode.LastCycle(); i++) {
+  for (int i = KCode.FirstCycle(); i < KCode.LastCycle(); i++) {
 
     if (KCode.get_myrank() == 0) cout << " ======= Cycle " << i << " ======= " << endl;
 

--- a/include/Particles3Dcomm.h
+++ b/include/Particles3Dcomm.h
@@ -227,6 +227,12 @@ protected:
   int nVar;
   /** Charge array */
   double *q;
+
+  /** Initial charge density */
+  double rhoINIT;
+  /** Injection charge density */
+  double rhoINJECT;
+
   /** Simulation domain lengths */
   double xstart, xend, ystart, yend, zstart, zend, invVOL;
   /** time step */

--- a/main/iPic3Dlib.cpp
+++ b/main/iPic3Dlib.cpp
@@ -101,14 +101,6 @@ int c_Solver::Init(int argc, char **argv) {
         else if (col->getCase()=="BATSRUS")   part[i].MaxwellianFromFluid(grid,EMf,vct,col,i);
         else                                  part[i].maxwellian(grid, EMf, vct);
 
-      // TEST
-      //if (col->getCase()=="Dipole") {
-      //  for (int i=0; i < ns; i++){
-      //    part[i].deleteParticlesInsideSphere(col->getL_square(),col->getx_center(),col->gety_center(),col->getz_center());
-      //  }
-      //}
-      // END TEST
-
     }
   }
 
@@ -374,8 +366,8 @@ void c_Solver::WriteOutput(int cycle) {
     /* Parallel HDF5 output using the H5hut library */
     /* -------------------------------------------- */
 
-    if (cycle%(col->getFieldOutputCycle())==0)     WriteFieldsH5hut(ns, grid, EMf, col, vct, cycle);
-    if (cycle%(col->getParticlesOutputCycle())==0) WritePartclH5hut(ns, grid, part, col, vct, cycle);
+    if (cycle%(col->getFieldOutputCycle())==0)                                    WriteFieldsH5hut(ns, grid, EMf,  col, vct, cycle);
+    if (cycle%(col->getParticlesOutputCycle())==0 && cycle!=col->getLast_cycle()) WritePartclH5hut(ns, grid, part, col, vct, cycle);
 
   }
   else

--- a/particles/Particles3D.cpp
+++ b/particles/Particles3D.cpp
@@ -786,9 +786,11 @@ int Particles3D::particle_repopulator(Grid* grid,VirtualTopology3D* vct, Field* 
                 harvest =   rand()/(double)RAND_MAX ;
                 z[particles_index] = (kk + harvest)*(dz/npcelz) + grid->getZN(i,j,k);
                 // q = charge
-                double rho = EMf->getRHOcs(i,j,k,is);
-                q[particles_index] = (qom / fabs(qom))*(rho/npcel)*(1.0/grid->getInvVOL());
-                //q[particles_index] =  (qom/fabs(qom))*(Ninj/FourPI/npcel)*(1.0/grid->getInvVOL());
+                /* ATTENTION: OVther methods can be use, i.e. using the values close to the boundary:
+                   double rho = abs(EMf->getRHOcs(4,j,k,is));
+                   q[particles_index] = (qom / fabs(qom))*(fabs(rho)/npcel)*(1.0/grid->getInvVOL());
+                */
+                q[particles_index] = (qom / fabs(qom))*(rhoINJECT/FourPI/npcel)*(1.0/grid->getInvVOL());
                 // u
                 harvest =   rand()/(double)RAND_MAX;
                 prob  = sqrt(-2.0*log(1.0-.999999*harvest));
@@ -848,9 +850,11 @@ int Particles3D::particle_repopulator(Grid* grid,VirtualTopology3D* vct, Field* 
                 harvest =   rand()/(double)RAND_MAX ;
                 z[particles_index] = (kk + harvest)*(dz/npcelz) + grid->getZN(i,j,k);
                 // q = charge
-                double rho = EMf->getRHOcs(i,j,k,is);
-                q[particles_index] = (qom / fabs(qom))*(rho/npcel)*(1.0/grid->getInvVOL());
-                //q[particles_index] =  (qom/fabs(qom))*(Ninj/FourPI/npcel)*(1.0/grid->getInvVOL());
+                /* ATTENTION: OVther methods can be use, i.e. using the values close to the boundary:
+                   double rho = abs(EMf->getRHOcs(i,4,k,is));
+                   q[particles_index] = (qom / fabs(qom))*(fabs(rho)/npcel)*(1.0/grid->getInvVOL());
+                */
+                q[particles_index] = (qom / fabs(qom))*(rhoINJECT/FourPI/npcel)*(1.0/grid->getInvVOL());
                 // u
                 harvest =   rand()/(double)RAND_MAX;
                 prob  = sqrt(-2.0*log(1.0-.999999*harvest));
@@ -906,9 +910,11 @@ int Particles3D::particle_repopulator(Grid* grid,VirtualTopology3D* vct, Field* 
                 harvest =   rand()/(double)RAND_MAX ;
                 z[particles_index] = (kk + harvest)*(dz/npcelz) + grid->getZN(i,j,k);
                 // q = charge
-                double rho = EMf->getRHOcs(i,j,k,is);
-                q[particles_index] = (qom / fabs(qom))*(rho/npcel)*(1.0/grid->getInvVOL());
-                //q[particles_index] =  (qom/fabs(qom))*(Ninj/FourPI/npcel)*(1.0/grid->getInvVOL());
+                /* ATTENTION: OVther methods can be use, i.e. using the values close to the boundary:
+                   double rho = abs(EMf->getRHOcs(i,j,4,is));
+                   q[particles_index] = (qom / fabs(qom))*(fabs(rho)/npcel)*(1.0/grid->getInvVOL());
+                */
+                q[particles_index] = (qom / fabs(qom))*(rhoINJECT/FourPI/npcel)*(1.0/grid->getInvVOL());
                 // u
                 harvest =   rand()/(double)RAND_MAX;
                 prob  = sqrt(-2.0*log(1.0-.999999*harvest));
@@ -963,9 +969,11 @@ int Particles3D::particle_repopulator(Grid* grid,VirtualTopology3D* vct, Field* 
                 harvest =   rand()/(double)RAND_MAX ;
                 z[particles_index] = (kk + harvest)*(dz/npcelz) + grid->getZN(i,j,k);
                 // q = charge
-                double rho = EMf->getRHOcs(i,j,k,is);
-                q[particles_index] = (qom / fabs(qom))*(rho/npcel)*(1.0/grid->getInvVOL());
-                //q[particles_index] =  (qom/fabs(qom))*(Ninj/FourPI/npcel)*(1.0/grid->getInvVOL());
+                /* ATTENTION: OVther methods can be use, i.e. using the values close to the boundary:
+                   double rho = abs(EMf->getRHOcs(grid->getNXC()-5,j,k,is));
+                   q[particles_index] = (qom / fabs(qom))*(fabs(rho)/npcel)*(1.0/grid->getInvVOL());
+                */
+                q[particles_index] = (qom / fabs(qom))*(rhoINJECT/FourPI/npcel)*(1.0/grid->getInvVOL());
                 // u
                 harvest =   rand()/(double)RAND_MAX;
                 prob  = sqrt(-2.0*log(1.0-.999999*harvest));
@@ -1021,9 +1029,11 @@ int Particles3D::particle_repopulator(Grid* grid,VirtualTopology3D* vct, Field* 
                 harvest =   rand()/(double)RAND_MAX ;
                 z[particles_index] = (kk + harvest)*(dz/npcelz) + grid->getZN(i,j,k);
                 // q = charge
-                double rho = EMf->getRHOcs(i,j,k,is);
-                q[particles_index] = (qom / fabs(qom))*(rho/npcel)*(1.0/grid->getInvVOL());
-                //q[particles_index] =  (qom/fabs(qom))*(Ninj/FourPI/npcel)*(1.0/grid->getInvVOL());
+                /* ATTENTION: OVther methods can be use, i.e. using the values close to the boundary:
+                   double rho = abs(EMf->getRHOcs(i,grid->getNYC()-5,k,is));
+                   q[particles_index] = (qom / fabs(qom))*(fabs(rho)/npcel)*(1.0/grid->getInvVOL());
+                */
+                q[particles_index] = (qom / fabs(qom))*(rhoINJECT/FourPI/npcel)*(1.0/grid->getInvVOL());
                 // u
                 harvest =   rand()/(double)RAND_MAX;
                 prob  = sqrt(-2.0*log(1.0-.999999*harvest));
@@ -1079,9 +1089,11 @@ int Particles3D::particle_repopulator(Grid* grid,VirtualTopology3D* vct, Field* 
                 harvest =   rand()/(double)RAND_MAX ;
                 z[particles_index] = (kk + harvest)*(dz/npcelz) + grid->getZN(i,j,k);
                 // q = charge
-                double rho = EMf->getRHOcs(i,j,k,is);
-                q[particles_index] = (qom / fabs(qom))*(rho/npcel)*(1.0/grid->getInvVOL());
-                //q[particles_index] =  (qom/fabs(qom))*(Ninj/FourPI/npcel)*(1.0/grid->getInvVOL());
+                /* ATTENTION: OVther methods can be use, i.e. using the values close to the boundary:
+                   double rho = abs(EMf->getRHOcs(i,j,grid->getNZC()-5,is));
+                   q[particles_index] = (qom / fabs(qom))*(fabs(rho)/npcel)*(1.0/grid->getInvVOL());
+                */
+                q[particles_index] = (qom / fabs(qom))*(rhoINJECT/FourPI/npcel)*(1.0/grid->getInvVOL());
                 // u
                 harvest =   rand()/(double)RAND_MAX;
                 prob  = sqrt(-2.0*log(1.0-.999999*harvest));

--- a/particles/Particles3Dcomm.cpp
+++ b/particles/Particles3Dcomm.cpp
@@ -88,6 +88,9 @@ void Particles3Dcomm::allocate(int species, long long initnpmax, Collective * co
     nop   = initnpmax;
   }
 
+  rhoINIT   = col->getRHOinit(species);
+  rhoINJECT = col->getRHOinject(species);
+
   qom = col->getQOM(species);
   uth = col->getUth(species);
   vth = col->getVth(species);


### PR DESCRIPTION
Particle repopulator was incorrectly started using the routine EMF->getRHOcs. There was a missing abs().
In addition a few updates and cleaning was done:
- Changing the use of ff to qom/abs(qom) to get the sign of the charge everywhere.
- Enlarged field damping layer.
- Do not write the particles file at the begginig of the simulation (h5hut option).
- Repopulator now uses rhoINJECT to inject particles. Comments were added in case the user wants to use another method.
- Fext, used in the Dipole case, uses now a 10-step increment to rise the dipolar field.
