### PR TITLE
Bug corrections and Dipole case modifications

### DIFF
--- a/fields/EMfields3D.cpp
+++ b/fields/EMfields3D.cpp
@@ -2160,7 +2160,7 @@ void EMfields3D::UpdateFext(int cycle){
 
   double t_beg = 500.0;
   double t_end = 3000.0;
-  double Fmin  = 0.02;
+  double Fmin  = 1.0;
   double Fmax  = 1.0;
 
   double m     = (Fmax - Fmin) / (t_end - t_beg);
@@ -2912,13 +2912,22 @@ void EMfields3D::updateInfoFields(Grid *grid,VirtualTopology3D *vct,Collective *
       for (int j=0; j<nyn;j++)
         for (int k=0; k<nzn;k++){
 
-          double Bxb = B0x;
-          double Byb = B0y;
-          double Bzb = B0z;
+          double Bxb = Bxn[i][j][k];
+          double Byb = Byn[i][j][k];
+          double Bzb = Bzn[i][j][k];
+          double Exb = w_0*Byb-v_0*Bzb;
+          double Eyb = u_0*Bzb-w_0*Bxb;
+          double Ezb = v_0*Bxb-u_0*Byb;
+          //double Bxb = 0.0;
+          //double Byb = 0.0;
+          //double Bzb = 0.0;
+          //double Exb = 0.0;
+          //double Eyb = 0.0;
+          //double Ezb = 0.0;
 
-          injFieldsLeft->ExITemp[i][j][k]=w_0*Byb-v_0*Bzb;
-          injFieldsLeft->EyITemp[i][j][k]=u_0*Bzb-w_0*Bxb;
-          injFieldsLeft->EzITemp[i][j][k]=v_0*Bxb-u_0*Byb;
+          injFieldsLeft->ExITemp[i][j][k]=Exb;
+          injFieldsLeft->EyITemp[i][j][k]=Eyb;
+          injFieldsLeft->EzITemp[i][j][k]=Ezb;
 
           injFieldsLeft->BxITemp[i][j][k]=Bxb;
           injFieldsLeft->ByITemp[i][j][k]=Byb;
@@ -2932,18 +2941,18 @@ void EMfields3D::updateInfoFields(Grid *grid,VirtualTopology3D *vct,Collective *
       for (int j=0; j<nyn; j++)
         for (int k=0; k<nzn; k++){
 
-          //double Bxb = Bxn[i][j][k];
-          //double Byb = Byn[i][j][k];
-          //double Bzb = Bzn[i][j][k];
-          //double Exb = w_0*Byb-v_0*Bzb;
-          //double Eyb = u_0*Bzb-w_0*Bxb;
-          //double Ezb = v_0*Bxb-u_0*Byb;
-          double Bxb = 0.0;
-          double Byb = 0.0;
-          double Bzb = 0.0;
-          double Exb = 0.0;
-          double Eyb = 0.0;
-          double Ezb = 0.0;
+          double Bxb = B0x;
+          double Byb = B0y;
+          double Bzb = B0z;
+          double Exb = w_0*Byb-v_0*Bzb;
+          double Eyb = u_0*Bzb-w_0*Bxb;
+          double Ezb = v_0*Bxb-u_0*Byb;
+          //double Bxb = 0.0;
+          //double Byb = 0.0;
+          //double Bzb = 0.0;
+          //double Exb = 0.0;
+          //double Eyb = 0.0;
+          //double Ezb = 0.0;
 
           injFieldsRight->ExITemp[i][j][k]=Exb;
           injFieldsRight->EyITemp[i][j][k]=Eyb;
@@ -3336,6 +3345,10 @@ double ***EMfields3D::getBx() {
   return (Bxn);
 }
 /*! get Magnetic Field component X array cell without the ghost cells */
+double EMfields3D::getBxc(int i, int j, int k) {
+  return (Bxc[i][j][k]);
+}
+/*! get Magnetic Field component X array cell without the ghost cells */
 double ***EMfields3D::getBxc() {
   return (Bxc);
 }
@@ -3348,6 +3361,10 @@ double ***EMfields3D::getBy() {
   return (Byn);
 }
 /*! get Magnetic Field component Y array cell without the ghost cells */
+double EMfields3D::getByc(int i, int j, int k) {
+  return (Byc[i][j][k]);
+}
+/*! get Magnetic Field component Y array cell without the ghost cells */
 double ***EMfields3D::getByc() {
   return (Byc);
 }
@@ -3358,6 +3375,10 @@ double &EMfields3D::getBz(int indexX, int indexY, int indexZ) const {
 /*! get Magnetic Field component Z array */
 double ***EMfields3D::getBz() {
   return (Bzn);
+}
+/*! get Magnetic Field component Z array cell without the ghost cells */
+double EMfields3D::getBzc(int i, int j, int k) {
+  return (Bzc[i][j][k]);
 }
 /*! get Magnetic Field component Z array cell without the ghost cells */
 double ***EMfields3D::getBzc() {

--- a/iPic3D.cpp
+++ b/iPic3D.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv) {
   /* 1- Main loop */
   /* ------------ */
 
-  for (int i = KCode.FirstCycle(); i < KCode.LastCycle(); i++) {
+  for (int i = KCode.FirstCycle(); i <= KCode.LastCycle(); i++) {
 
     if (KCode.get_myrank() == 0) cout << " ======= Cycle " << i << " ======= " << endl;
 
@@ -37,10 +37,7 @@ int main(int argc, char **argv) {
 
     if (!b_err) KCode.CalculateBField();
     if (!b_err) KCode.GatherMoments();
-
-    if (b_err) {
-      i = KCode.LastCycle() + 1;
-    }
+    if ( b_err) i = KCode.LastCycle() + 1;
 
     /* --------------- */
     /* 3- Output files */

--- a/include/EMfields3D.h
+++ b/include/EMfields3D.h
@@ -322,17 +322,23 @@ class EMfields3D                // :public Field
     /*! get Magnetic field X component array */
     double ***getBx();
     /*! get Magnetic field X component cell array without the ghost cells */
+    double getBxc(int i, int j, int k);
+    /*! get Magnetic field X component cell array without the ghost cells */
     double ***getBxc();
     /*! get Magnetic Field component Y defined on node(indexX,indexY,indexZ) */
     double &getBy(int indexX, int indexY, int indexZ) const;
     /*! get Magnetic field Y component array */
     double ***getBy();
     /*! get Magnetic field Y component cell array without the ghost cells */
+    double getByc(int i, int j, int k);
+    /*! get Magnetic field Y component cell array without the ghost cells */
     double ***getByc();
     /*! get Magnetic Field component Z defined on node(indexX,indexY,indexZ) */
     double &getBz(int indexX, int indexY, int indexZ) const;
     /*! get Magnetic field Z component array */
     double ***getBz();
+    /*! get Magnetic field Z component cell array without the ghost cells */
+    double getBzc(int i, int j, int k);
     /*! get Magnetic field Z component cell array without the ghost cells */
     double ***getBzc();
     /*! get density on cell(indexX,indexY,indexZ) */

--- a/include/ParallelIO.h
+++ b/include/ParallelIO.h
@@ -25,7 +25,7 @@ void WriteFieldsH5hut(int nspec, Grid3DCU *grid, EMfields3D *EMf, Collective *co
 void WritePartclH5hut(int nspec, Grid3DCU *grid, Particles3Dcomm *part, Collective *col, VCtopology3D *vct, int cycle);
 
 void ReadPartclH5hut(int nspec, Particles3Dcomm *part, Collective *col, VCtopology3D *vct, Grid3DCU *grid);
-void ReadFieldsH5hut(int nspec, EMfields3D *EMf,       Collective *col, VCtopology3D *vct, Grid3DCU *grid);
+void ReadFieldsH5hut(int nspec, bool readext, EMfields3D *EMf,       Collective *col, VCtopology3D *vct, Grid3DCU *grid);
 
 void WriteOutputParallel(Grid3DCU *grid, EMfields3D *EMf, Particles3Dcomm *part, Collective *col, VCtopology3D *vct, int cycle);
 

--- a/include/Particles3D.h
+++ b/include/Particles3D.h
@@ -36,6 +36,8 @@ class Particles3D:public Particles3Dcomm {
     void constantVelocity(double vel, int dim, Grid * grid, Field * EMf);
     /** Initial condition: uniform in space and maxwellian in velocity */
     void maxwellian(Grid * grid, Field * EMf, VirtualTopology3D * vct);
+    /** Initial condition: uniform in space and maxwellian in velocity */
+    void MaxwellianFromFields(Grid * grid, Field * EMf, VirtualTopology3D * vct);
     /** Force Free initialization (JxB=0) for particles */
     void force_free(Grid * grid, Field * EMf, VirtualTopology3D * vct);
     /** Initial condition: uniform in space and maxwellian in velocity */

--- a/include/iPic3D.h
+++ b/include/iPic3D.h
@@ -94,7 +94,7 @@ namespace iPic3D {
     return (first_cycle);
   }
   inline int c_Solver::LastCycle() {
-    return (col->getNcycles() + first_cycle);
+    return (col->getNcycles() + first_cycle-1);
   }
   inline int c_Solver::get_myrank() {
     return (myrank);

--- a/inputfiles/GEM-Birn.inp
+++ b/inputfiles/GEM-Birn.inp
@@ -1,0 +1,131 @@
+# INPUT FILE for GEM challenge case
+# 2 Species
+
+#  %%%%%%%%%%%%%%%%%%% Input/Output flags %%%%%%%%%%%%%%%%%%
+SaveDirName    = "data"     # Output directory (without trailing "/")
+RestartDirName = "data"     # Restart directory (for WriteMethod=default)
+
+#  %%%%%%%%%%%%%%%%%%% Input/Output flags %%%%%%%%%%%%%%%%%%
+
+Case              = GEM                             # Case [ GEM | Dipole | ... ]
+FieldsInit        = ./data/Initial-Fields_000000.h5 # Initial fields h5 file
+PartInit          = Maxwell                         # Initial particles [ Maxwell | File ]
+WriteMethod       = Parallel                        # Output method [ default | Parallel ]
+PoissonCorrection = yes                             # Poisson correction [ yes | no ]
+SimulationName    = GEM                             # Simulation name for the output
+
+#  %%%%%%%%%%%%%%%%%%% Magnetic Reconnection %%%%%%%%%%%%%%%%%%
+B0x = 0.0097
+B0y = 0.00
+B0z = 0.00
+
+# External magnetic field parameters:
+B1x = 0.000
+B1y = 0.000
+B1z = 0.000
+
+delta = 0.5
+
+#  %%%%%%%%%%%%%%%%%%% TIME %%%%%%%%%%%%%%%%%%
+dt = 0.5               # dt = time step
+ncycles = 150          # cycles
+th = 1.0               # th =   decentering parameter
+c = 1.0                # c = light speed
+
+#  %%%%%%%%%%%%%%%%%%% SMOOTH %%%%%%%%%%%%%%%%%%
+Smooth = 0.5           # Smoothing value (5-points stencil)
+
+
+# %%%%%%%%%%%%%%%%%% BOX SIZE %%%%%%%%%%%%%%%
+Lx =   25.6            # Lx = simulation box length - x direction
+Ly =   12.8            # Ly = simulation box length - y direction
+Lz =   1.0             # Lz = simulation box length - z direction
+
+x_center =   1.        # Lx = simulation box length - x direction in m
+y_center =   1.        # Ly = simulation box length - y direction in m
+z_center =   1.        # Lz = simulation box length - z direction in m
+L_square =   .1
+
+nxc = 512              # nxc = number of cells - x direction
+nyc = 256              # nyc = number of cells - y direction
+nzc =  1               # nzc = number of cells - z direction
+
+# %%%%%%%%%%%%%%%%%% MPI TOPOLOGY %%%%%%%%%%%%%%%
+XLEN = 2               # Number of subdomains in the X direction
+YLEN = 2               # Number of subdomains in the X direction
+ZLEN = 1               # Number of subdomains in the X direction
+
+# %%%%%%%%%%%%%% PARTICLES %%%%%%%%%%%%%%%%%
+#    0 = electrons
+#    1 = protons
+#    2,3,4,5,... = ions
+# %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+ns = 2                               # Number of particles
+rhoINIT         = 1.0  1.0           # Initial density (make sure you are neutral)
+rhoINJECT       = 1.0  1.0           # Injection density (make sure you are neutral)
+TrackParticleID = 0    0             # TrackParticleID[species] = 1=true, 0=false
+
+npcelx          = 12   12            # Particles per cell in X
+npcely          = 12   12            # Particles per cell in Y
+npcelz          = 12   12            # Particles per cell in Z
+NpMaxNpRatio    = 3.0                # Maximum number of particles allocated
+
+qom             = -25.0   1.0        # Charge/mass ratio
+uth             = 0.045   0.0063     # Thermal velocity in X
+vth             = 0.045   0.0063     # Thermal velocity in Y
+wth             = 0.045   0.0063     # Thermal velocity in Z
+u0              = 0.0     0.0        # Drift velocity in X
+v0              = 0.0     0.0        # Drift velocity in Y
+w0              = 0.00325 -0.01624   # Drift velocity in Z
+
+# %%%%%%%%%%%% Periodicity in each direction %%%%%%%%%%%%%%%
+PERIODICX       = 1                  # In direction X (1=true, 0=false)
+PERIODICY       = 0                  # In direction Y (1=true, 0=false)
+PERIODICZ       = 1                  # In direction Z (1=true, 0=false)
+
+# %%%%%%%%%%%% boundary conditions %%%%%%%%%%%%%%%
+# If the PERIODIC flag is active in the previous section
+# periodic boundary conditions will be imposed
+#
+# PHI Electrostatic Potential
+# 0,1 = Dirichilet boundary condition ;
+# 2   = Neumann boundary condition
+    bcPHIfaceXright = 1
+    bcPHIfaceXleft  = 1
+    bcPHIfaceYright = 1
+    bcPHIfaceYleft  = 1
+    bcPHIfaceZright = 1
+    bcPHIfaceZleft  = 1
+
+#    EM field boundary condition
+#    0 = perfect conductor
+#    1 = magnetic mirror
+    bcEMfaceXright = 0
+    bcEMfaceXleft =  0
+    bcEMfaceYright = 0
+    bcEMfaceYleft =  0
+    bcEMfaceZright = 0
+    bcEMfaceZleft =  0
+
+#    Particles Boundary condition
+#    0 = exit
+#    1 = perfect mirror
+#    2 = riemission
+    bcPfaceXright = 1
+    bcPfaceXleft =  1
+    bcPfaceYright = 1
+    bcPfaceYleft =  1
+    bcPfaceZright = 1
+    bcPfaceZleft =  1
+
+# %%%%%%%%%%%% Numerics options %%%%%%%%%%%%%%%
+verbose                = 1        # Print to video results
+Vinj                   = 0.0      # Velocity of the injection from the wall
+CGtol                  = 1E-3     # CG solver stopping criterium tolerance
+GMREStol               = 1E-3     # GMRES solver stopping criterium tolerance
+NiterMover             = 3        # mover predictor corrector iteration
+FieldOutputCycle       = 100      # Output for field
+ParticlesOutputCycle   = 100      # Output for particles if 1 it doesnt save particles data
+RestartOutputCycle     = 4000     # restart cycle
+DiagnosticsOutputCycle = 1        # Diagnostics cycle

--- a/inputoutput/ParallelIO.cpp
+++ b/inputoutput/ParallelIO.cpp
@@ -285,7 +285,7 @@ void ReadPartclH5hut(int nspec, Particles3Dcomm *part, Collective *col, VCtopolo
 #endif
 }
 
-void ReadFieldsH5hut(int nspec, EMfields3D *EMf, Collective *col, VCtopology3D *vct, Grid3DCU *grid){
+void ReadFieldsH5hut(int nspec, bool readext, EMfields3D *EMf, Collective *col, VCtopology3D *vct, Grid3DCU *grid){
 #ifdef USEH5HUT
 
   H5input infile;
@@ -305,6 +305,12 @@ void ReadFieldsH5hut(int nspec, EMfields3D *EMf, Collective *col, VCtopology3D *
   infile.ReadFields(EMf->getBx(), "Bx", grid->getNXN(), grid->getNYN(), grid->getNZN());
   infile.ReadFields(EMf->getBy(), "By", grid->getNXN(), grid->getNYN(), grid->getNZN());
   infile.ReadFields(EMf->getBz(), "Bz", grid->getNXN(), grid->getNYN(), grid->getNZN());
+
+  if (readext) {
+    infile.ReadFields(EMf->getBx_ext(), "Btx", grid->getNXN(), grid->getNYN(), grid->getNZN());
+    infile.ReadFields(EMf->getBy_ext(), "Bty", grid->getNXN(), grid->getNYN(), grid->getNZN());
+    infile.ReadFields(EMf->getBz_ext(), "Btz", grid->getNXN(), grid->getNYN(), grid->getNZN());
+  }
 
   for (int is = 0; is < nspec; is++){
     std::stringstream  ss;
@@ -327,15 +333,11 @@ void ReadFieldsH5hut(int nspec, EMfields3D *EMf, Collective *col, VCtopology3D *
   grid->interpN2C(EMf->getByc(), EMf->getBy());
   grid->interpN2C(EMf->getBzc(), EMf->getBz());
 
-  // Comm ghost cells for B-field
-  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getBx(), col->bcBx[0],col->bcBx[1],col->bcBx[2],col->bcBx[3],col->bcBx[4],col->bcBx[5], vct);
-  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getBy(), col->bcBy[0],col->bcBy[1],col->bcBy[2],col->bcBy[3],col->bcBy[4],col->bcBy[5], vct);
-  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getBz(), col->bcBz[0],col->bcBz[1],col->bcBz[2],col->bcBz[3],col->bcBz[4],col->bcBz[5], vct);
 
   // communicate E
-  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getEx(), col->bcBx[0],col->bcBx[1],col->bcBx[2],col->bcBx[3],col->bcBx[4],col->bcBx[5], vct);
-  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getEy(), col->bcBy[0],col->bcBy[1],col->bcBy[2],col->bcBy[3],col->bcBy[4],col->bcBy[5], vct);
-  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getEz(), col->bcBz[0],col->bcBz[1],col->bcBz[2],col->bcBz[3],col->bcBz[4],col->bcBz[5], vct);
+  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getEx(), col->bcEx[0],col->bcEx[1],col->bcEx[2],col->bcEx[3],col->bcEx[4],col->bcEx[5], vct);
+  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getEy(), col->bcEy[0],col->bcEy[1],col->bcEy[2],col->bcEy[3],col->bcEy[4],col->bcEy[5], vct);
+  communicateNodeBC(grid->getNXN(), grid->getNYN(), grid->getNZN(), EMf->getEz(), col->bcEz[0],col->bcEz[1],col->bcEz[2],col->bcEz[3],col->bcEz[4],col->bcEz[5], vct);
 
   for (int is = 0; is < nspec; is++)
     grid->interpN2C(EMf->getRHOcs(), is, EMf->getRHOns());


### PR DESCRIPTION
Bug correction: injected particles were initialized with the wrong charge sign. Attention to the use of the fabs(qom)/qom.

Adding getBx(i,j,k). Adding an option to read the Bext from a file. Adding the initialization of drift velocities using the initial ExB. Particles are not saved at the initial iteration anymore (it uses too much disk space in some systems).

This version has been tested with external hdf5 fields initialization.
